### PR TITLE
Security improving

### DIFF
--- a/ci-cd-platform-deployment/sample_project/front/apache.conf
+++ b/ci-cd-platform-deployment/sample_project/front/apache.conf
@@ -66,12 +66,11 @@ LoadModule mpm_event_module modules/mod_mpm_event.so
   <Files index.html>
     FileETag None
     <ifModule mod_headers.c>
-      #Security headers
+      # Security
       Header always set X-Frame-Options DENY
       Header always set X-Content-Type-Options nosniff
       Header set X-XSS-Protection "1; mode=block"
-      #Whenever https is ready, enable HSTS (uncomment line below)
-      #Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
+      # Caching
       Header unset ETag
       Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
       Header set Pragma "no-cache"

--- a/ci-cd-platform-deployment/sample_project/front/apache.conf
+++ b/ci-cd-platform-deployment/sample_project/front/apache.conf
@@ -69,6 +69,7 @@ LoadModule mpm_event_module modules/mod_mpm_event.so
       #Security headers
       Header always set X-Frame-Options DENY
       Header always set X-Content-Type-Options nosniff
+      Header set X-XSS-Protection "1; mode=block"
       #Whenever https is ready, enable HSTS (uncomment line below)
       #Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
       Header unset ETag

--- a/ci-cd-platform-deployment/sample_project/front/apache.conf
+++ b/ci-cd-platform-deployment/sample_project/front/apache.conf
@@ -66,6 +66,11 @@ LoadModule mpm_event_module modules/mod_mpm_event.so
   <Files index.html>
     FileETag None
     <ifModule mod_headers.c>
+      #Security headers
+      Header always set X-Frame-Options DENY
+      Header always set X-Content-Type-Options nosniff
+      #Whenever https is ready, enable HSTS (uncomment line below)
+      #Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
       Header unset ETag
       Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
       Header set Pragma "no-cache"


### PR DESCRIPTION
**I added security headers for apache:**

*Header always set X-Frame-Options DENY*

Will protect users from i-frame click jacking

*Header always set X-Content-Type-Options nosniff*

Will protect users against MIME sniffing

*Header set X-XSS-Protection "1; mode=block"*

Will protect users if the browser detect a reflected XSS

*Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"*

Will insure that the web site in browsed in HTTPS no matter what

PS: A **Content-Security-Policy:** header should be set as well, but the configuration will depends on each situation
 